### PR TITLE
Improve symbol naming

### DIFF
--- a/fxp2smt.py
+++ b/fxp2smt.py
@@ -42,6 +42,9 @@ else:
 
 for x in F.get_free_variables():
     print("(declare-fun {} {})".format(x.to_smtlib(), x._content.payload[1].as_smtlib(funstyle=True)))
+
+for old_n, new_n in conv.symbol_map.items():
+    print("(define-fun {} {} {})".format(old_n.to_smtlib(), new_n.get_type().as_smtlib(), new_n.to_smtlib()))
 print("(assert {})".format(F.to_smtlib()))
 print("(check-sat)")
 

--- a/fxp2smt.py
+++ b/fxp2smt.py
@@ -49,7 +49,7 @@ for old_n, new_n in conv.symbol_map.items():
 for x in F.get_free_variables():
     if x in inv_sm.keys():
         old_n = inv_sm[x]
-        print("(define-fun {} {} {})".format(x.to_smtlib(), old_n.get_type().as_smtlib(), old_n.to_smtlib()))
+        print("(define-fun {} {} {})".format(x.to_smtlib(), x.get_type().as_smtlib(), old_n.to_smtlib()))
     else:
         print("(declare-fun {} {})".format(x.to_smtlib(), x._content.payload[1].as_smtlib(funstyle=True)))
 print("(assert {})".format(F.to_smtlib()))

--- a/fxp2smt.py
+++ b/fxp2smt.py
@@ -42,9 +42,6 @@ else:
 
 for x in F.get_free_variables():
     print("(declare-fun {} {})".format(x.to_smtlib(), x._content.payload[1].as_smtlib(funstyle=True)))
-
-for old_n, new_n in conv.symbol_map.items():
-    print("(define-fun {} {} {})".format(old_n.to_smtlib(), new_n.get_type().as_smtlib(), new_n.to_smtlib()))
 print("(assert {})".format(F.to_smtlib()))
 print("(check-sat)")
 

--- a/fxp2smt.py
+++ b/fxp2smt.py
@@ -40,8 +40,18 @@ if BV:
 else:
     print("(set-logic QF_NIRA)")
 
+sm = conv.symbol_map
+inv_sm = {v:k for k, v in sm.items()}
+
+for old_n, new_n in conv.symbol_map.items():
+    print("(declare-fun {} {})".format(old_n.to_smtlib(), new_n._content.payload[1].as_smtlib(funstyle=True)))
+
 for x in F.get_free_variables():
-    print("(declare-fun {} {})".format(x.to_smtlib(), x._content.payload[1].as_smtlib(funstyle=True)))
+    if x in inv_sm.keys():
+        old_n = inv_sm[x]
+        print("(define-fun {} {} {})".format(x.to_smtlib(), old_n.get_type().as_smtlib(), old_n.to_smtlib()))
+    else:
+        print("(declare-fun {} {})".format(x.to_smtlib(), x._content.payload[1].as_smtlib(funstyle=True)))
 print("(assert {})".format(F.to_smtlib()))
 print("(check-sat)")
 

--- a/pysmt/formula.py
+++ b/pysmt/formula.py
@@ -1094,16 +1094,18 @@ class FormulaManager(object):
                                 args=(om, rm, src),
                                 payload=(tb, fb))
 
-    def TOUFXP(self, om, rm, src, tb, fb):
-        if type(fb) is FNode and (fb.node_type() is op.INT_CONSTANT or
-                                  fb.node_type() is op.REAL_CONSTANT):
-                fb = int(fb._content.payload)
-        if type(tb) is FNode and (tb.node_type() is op.INT_CONSTANT or
-                                  tb.node_type() is op.REAL_CONSTANT):
-                tb = int(tb._content.payload)
+    def TOUFXP(self, om, rm, src, to_tb, to_fb):
+        src_ty = self.env.stc.get_type(src)
+        if type(to_fb) is FNode and (to_fb.node_type() is op.INT_CONSTANT or
+                                  to_fb.node_type() is op.REAL_CONSTANT):
+                to_fb = int(to_fb._content.payload)
+        if type(to_tb) is FNode and (to_tb.node_type() is op.INT_CONSTANT or
+                                  to_tb.node_type() is op.REAL_CONSTANT):
+                to_tb = int(to_tb._content.payload)
         return self.create_node(node_type=op.TO_UFXP,
                                 args=(om, rm, src),
-                                payload=(tb, fb))
+                                payload=(to_tb, to_fb,
+                                         src_ty._total_width, src_ty._frac_width))
 
     def UFXPLT(self, left, right):
         """Returns the formula left < right."""


### PR DESCRIPTION
This changes the `fxp2smt.py` conversion script to retain the source variable names, instead of using the fresh variable names from the target theory.
This also records further relevant information in the conversion operator formula nodes.